### PR TITLE
Catch empty queries.

### DIFF
--- a/rest-service/src/main/kotlin/mb/api/service/valid/SequenceValidationError.kt
+++ b/rest-service/src/main/kotlin/mb/api/service/valid/SequenceValidationError.kt
@@ -21,3 +21,8 @@ class SequenceLengthValidationError(
   override val message
     get() = "Sequence too long, max length is $maxLength input length was $length."
 }
+
+class SequenceEmptyValidationError : SequenceValidationError {
+  override val message: String
+    get() = "Empty query.  Query must have 1 or more sequences."
+}

--- a/rest-service/src/main/kotlin/mb/api/service/valid/SequenceValidator.kt
+++ b/rest-service/src/main/kotlin/mb/api/service/valid/SequenceValidator.kt
@@ -32,8 +32,11 @@ interface SequenceValidator {
    * @return Whether all characters in the input {@code CharSequence} are valid.
    */
   fun validate(sequence: Int, seq: String): SequenceValidationError? {
+    // Input scanner
     val scan = Scanner(seq)
+    // Current line number
     var lineNum = 1
+    // Number of sequence lines in the input.
     var size = 0
 
     while (scan.hasNextLine()) {
@@ -51,8 +54,13 @@ interface SequenceValidator {
       lineNum++
     }
 
+    // If the query had no sequence lines.
+    if (size == 0)
+      return SequenceEmptyValidationError()
+
     if (size > maxSeqLength)
       return SequenceLengthValidationError(size, maxSeqLength)
+
     return null
   }
 


### PR DESCRIPTION
Multi-blast currently allows empty sequences through as long as full query is not empty (the query contains only header lines).

This should catch that issue and prevent empty jobs from making it through.

Resolves #105 