### PR TITLE
Reformat sequences before storing them.

### DIFF
--- a/rest-service/build.gradle.kts
+++ b/rest-service/build.gradle.kts
@@ -6,8 +6,8 @@ import java.util.*
 
 plugins {
   java
-  id("org.veupathdb.lib.gradle.container.container-utils") version "1.4.0"
-  kotlin("jvm") version "1.6.0"
+  id("org.veupathdb.lib.gradle.container.container-utils") version "3.0.0"
+  kotlin("jvm") version "1.6.10"
 }
 
 // Load Props
@@ -26,8 +26,12 @@ tasks.withType<KotlinCompile>().configureEach {
     jvmTarget = "16"
   }
 }
+
 containerBuild {
-  fgpUtilVersion = "14aa44a13c28257b702a98ddbecdf1e72812e2e6"
+  fgputil {
+    version = "c48c7e7"
+    targets = arrayOf(AccountDB, Core, DB, Web)
+  }
 }
 
 // Project settings
@@ -138,31 +142,6 @@ tasks.compileJava {
   options.compilerArgs.add("-Aproject=${project.group}/${project.name}")
 }
 
-tasks.jar {
-
-  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-  manifest {
-    attributes["Main-Class"] = "mb.Main"
-    attributes["Implementation-Title"] = buildProps["project.name"]
-    attributes["Implementation-Version"] = buildProps["project.version"]
-  }
-  println("Packaging Components")
-  from(configurations.runtimeClasspath.get().map {
-    println("  " + it.name)
-
-    if (it.isDirectory) it else zipTree(it).matching {
-      exclude { f ->
-        val name = f.name.toLowerCase()
-        (name.contains("log4j") && name.contains(".dat")) ||
-          name.endsWith(".sf") ||
-          name.endsWith(".dsa") ||
-          name.endsWith(".rsa")
-      } } })
-  archiveFileName.set("service.jar")
-}
-
-tasks.register("print-package") { print(fullPack) }
 tasks.register("print-container-name") { print(buildProps["container.name"]) }
 
 tasks.withType<Test> {

--- a/rest-service/makefile
+++ b/rest-service/makefile
@@ -71,7 +71,7 @@ install-dev-env:
 		cd .tools && git pull && cd ..; \
 	fi
 	@$(BIN_DIR)/check-env.sh
-	@./gradlew fgputilInstall --stacktrace
+	@./gradlew download-fgputil
 	@$(BIN_DIR)/install-oracle.sh
 
 fix-path:

--- a/rest-service/src/main/kotlin/mb/api/service/http/job/JobService.kt
+++ b/rest-service/src/main/kotlin/mb/api/service/http/job/JobService.kt
@@ -4,6 +4,7 @@ import mb.api.model.IOJobPostResponse
 import mb.api.model.IOJsonJobRequest
 import mb.api.model.io.JsonKeys
 import mb.api.service.model.ErrorMap
+import mb.api.service.valid.Sequences
 import mb.lib.blast.model.parseAsQuery
 import mb.lib.config.Config
 import mb.lib.query.BlastManager
@@ -29,14 +30,14 @@ class JobService {
   fun createJob(input: IOJsonJobRequest, userID: Long): IOJobPostResponse {
     Log.trace("#createJob(input={}, userID={})", input, userID)
 
-    var rawQuery = input.config.query
+    var rawQuery = Sequences.standardize(
+      input.config.query
+        ?: throw UnprocessableEntityException(ErrorMap(JsonKeys.Query, "Query is required."))
+    )
 
     // We are abusing the config query file field, null it out so it doesn't
     // get stored or sent anywhere with the query in this field.
     input.config.query = null
-
-    if (rawQuery == null)
-      throw UnprocessableEntityException(ErrorMap(JsonKeys.Query, "Query is required."))
 
     rawQuery = rawQuery.trim()
 

--- a/rest-service/src/main/kotlin/mb/api/service/valid/SequenceTransformer.kt
+++ b/rest-service/src/main/kotlin/mb/api/service/valid/SequenceTransformer.kt
@@ -1,0 +1,111 @@
+package mb.api.service.valid
+
+import java.util.Scanner
+
+/**
+ * Max line length for a sequence line.
+ */
+private const val SequenceLineLength = 80
+
+object Sequences {
+
+  /**
+   * Standardizes the input query into a query consisting of only the query
+   * sequence.
+   *
+   * The output will have no blank lines, no extra whitespaces, and will be
+   * broken into 80 character rows.
+   *
+   * Header lines will not be altered.
+   *
+   * Input:
+   * ```
+   * > Some really long header line containing a bunch of information that is more than 80 characters long.
+   * aaaaaaaaaaaaaa
+   * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   *
+   * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   * a
+   * ```
+   *
+   * Output
+   * ```
+   * > Some really long header line containing a bunch of information that is more than 80 characters long.
+   * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   * aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   * aaaaaaaaaaaaaaaaaaaaa
+   * ```
+   */
+  fun standardize(input: String): String {
+
+    // Input sequence scanner.
+    val scanner = Scanner(input)
+
+    // Buffer used to standardize lines to a set number of characters.
+    val lineBuffer = StringBuilder(SequenceLineLength)
+
+    // Output writer.
+    val writer = StringBuilder(input.length)
+
+    // Segment of an input line that could not fit into the line buffer.
+    var overflow: String
+
+    while (scanner.hasNextLine()) {
+      // Current line
+      val line     = scanner.nextLine().trim()
+
+      // If the line starts with a '>' character then it is a FASTA header line
+      // and should be written to the output stream unchanged.
+      if (line.startsWith('>')) {
+        writer.appendLine(line)
+
+        // If the line is empty, skip it, else write it out.
+      } else if (line.isNotBlank()) {
+        overflow = appendBuffer(lineBuffer, line)
+
+        // If the overflow string is not empty, then the line buffer must be
+        // full.
+        while (overflow != "") {
+          // Write the line buffer to the output stream.
+          writer.appendLine(lineBuffer)
+          lineBuffer.clear()
+          // Attempt to fill the line buffer again until there are no characters
+          // left in the overflow string.
+          overflow = appendBuffer(lineBuffer, overflow)
+        }
+
+        // If the line buffer is greater than (should never happen) or equal to
+        // the max sequence line length:
+        if (lineBuffer.length >= SequenceLineLength) {
+          writer.appendLine(lineBuffer)
+          lineBuffer.clear()
+        }
+      }
+    }
+
+    if (lineBuffer.isNotEmpty())
+      writer.appendLine(lineBuffer)
+
+    return writer.toString()
+  }
+
+  private fun appendBuffer(buf: StringBuilder, line: String): String {
+    // Buffer length
+    val bln = buf.length
+    // Input length
+    val iln = line.length
+
+    if (bln + iln <= SequenceLineLength) {
+      buf.append(line)
+      return ""
+    }
+
+    val substringLen = SequenceLineLength - bln
+
+    buf.append(line.substring(0, substringLen))
+
+    return line.substring(substringLen)
+  }
+
+}
+

--- a/rest-service/src/test/java/mb/api/service/valid/SequenceTransformerTest.kt
+++ b/rest-service/src/test/java/mb/api/service/valid/SequenceTransformerTest.kt
@@ -1,0 +1,74 @@
+package mb.api.service.valid
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+@DisplayName("Sequences")
+internal class SequenceTransformerTest {
+
+  @Nested
+  @DisplayName("#transform(String)")
+  inner class Transform {
+
+    @Test
+    @DisplayName("Omits empty lines.")
+    fun test1() {
+      val input = """> Test header line
+Some text that must be 80 characters per line so as to not invalidate the test b
+
+y having unrelated transformations going on in the transform method.  We only wa
+
+nt to test the empty line removal.
+"""
+
+      val expected = """> Test header line
+Some text that must be 80 characters per line so as to not invalidate the test b
+y having unrelated transformations going on in the transform method.  We only wa
+nt to test the empty line removal.
+"""
+
+      assertEquals(expected, Sequences.standardize(input))
+    }
+
+
+    @Test
+    @DisplayName("Trims leading margins.")
+    fun test2() {
+      val input = """> Test header line
+        Some text that must be 80 characters per line so as to not invalidate the test b
+        y having unrelated transformations going on in the transform method.  We only wa
+        nt to test the margin removal.
+        """
+
+      val expected = """> Test header line
+Some text that must be 80 characters per line so as to not invalidate the test b
+y having unrelated transformations going on in the transform method.  We only wa
+nt to test the margin removal.
+"""
+
+      assertEquals(expected, Sequences.standardize(input))
+    }
+
+    @Test
+    @DisplayName("Breaks/merges lines to 80 character rows.")
+    fun test3() {
+      val input = """>Test header line
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaa
+"""
+
+      val expected = """>Test header line
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"""
+
+      assertEquals(expected, Sequences.standardize(input))
+    }
+
+  }
+}


### PR DESCRIPTION
Input sequences will be standardized into 80 character rows with extra empty lines or margin spaces removed.


Resolves #91
Resolves #104