### PR TITLE
busy-wait for report file.

### DIFF
--- a/blast/formatter/server/internal/server/run-report-ep.go
+++ b/blast/formatter/server/internal/server/run-report-ep.go
@@ -122,6 +122,9 @@ func zipDir(path string) (err error) {
 
 		// If we found 1 or more files in the workspace, then the file has been
 		// copied in, and we can zip the report.
+		//
+		// The only things being zipped are the report output files, the `meta.json`
+		// file and the completed flag file are created after this zip is done.
 		if len(matches) > 0 {
 			if err := xfiles.ZipFiles(path, reportExportName, matches); err != nil {
 				return err

--- a/blast/formatter/server/internal/server/run-report-ep.go
+++ b/blast/formatter/server/internal/server/run-report-ep.go
@@ -114,7 +114,7 @@ func zipDir(path string) (err error) {
 	for i := 0; i < 10; i++ {
 
 		// Search for files in the workspace directory (will be empty until the
-		// formatter is complete and the report is copied into the workspace).
+		// report is copied into the workspace).
 		matches, err = filepath.Glob(filepath.Join(path, "*"))
 		if err != nil {
 			return err
@@ -135,6 +135,8 @@ func zipDir(path string) (err error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
+	// We waited a full second after the completion of the formatter and there is
+	// still no report file in the workspace.
 	return errors.New("no report file was found in workspace")
 }
 


### PR DESCRIPTION
To handle the possible race condition where we reach the file glob before the report file is copied into the workspace, the code will now busy-wait until the directory is not empty.

Closes #102