### PR TITLE
Add alias for "running" status

### DIFF
--- a/rest-service/src/main/kotlin/mb/lib/model/JobStatus.kt
+++ b/rest-service/src/main/kotlin/mb/lib/model/JobStatus.kt
@@ -17,8 +17,9 @@ enum class JobStatus(val value: String) {
   fun toJSON(): JsonNode = TextNode(value)
 
   companion object {
-    private const val InProgressAlias = "grabbed"
-    private const val QueuedAlias     = "claimed"
+    private const val InProgressAlias1 = "grabbed"
+    private const val InProgressAlias2 = "running"
+    private const val QueuedAlias      = "claimed"
 
     @JvmStatic
     fun fromString(name: String): JobStatus? {
@@ -27,9 +28,10 @@ enum class JobStatus(val value: String) {
           return e
 
       return when (name) {
-        QueuedAlias     -> Queued
-        InProgressAlias -> InProgress
-        else            -> null
+        QueuedAlias      -> Queued
+        InProgressAlias1 -> InProgress
+        InProgressAlias2 -> InProgress
+        else             -> null
       }
     }
 


### PR DESCRIPTION
Not sure where the "running" status is coming from, but we are about to gut and rewrite the internals to put mblast on the compute platform which will change all of this anyway.

So instead of wasting time investigating an issue that will be gone in the next couple months, I added an alias to `InProgress` from the value `"running"` to fix the 500.

Resolves #145