### PR TITLE
User link insert-if-not-exists.

### DIFF
--- a/rest-service/src/main/kotlin/mb/lib/query/db/InsertUserLink.kt
+++ b/rest-service/src/main/kotlin/mb/lib/query/db/InsertUserLink.kt
@@ -9,25 +9,36 @@ data class InsertUserLink(private val con: Connection, private val row: UserBlas
   companion object {
     private const val Query = """
     INSERT INTO
-      userlogins5.multiblast_users (
-        job_digest
-      , user_id
-      , description
-      , max_download_size
-      , run_directly
+      userlogins5.multiblast_users
+    SELECT
+      ?, ?, ?, ?, ?
+    FROM
+      dual
+    WHERE
+      NOT EXISTS (
+        SELECT
+          1
+        FROM
+          userlogins5.multiblast_users
+        WHERE
+          job_digest = ?
+        AND
+          user_id = ?
       )
-    VALUES
-      (?, ?, ?, ?, ?)
     """
   }
 
   fun run() = BasicPreparedVoidQuery(Query, con, this::prep).execute()
 
   private fun prep(ps: PreparedStatement) {
-    ps.setBytes(1, row.jobID!!.bytes)
+    // SELECT
+    ps.setBytes(1, row.jobID.bytes)
     ps.setLong(2, row.userID)
     ps.setString(3, row.description)
     ps.setLong(4, row.maxDownloadSize)
     ps.setBoolean(5, row.runDirectly)
+    // WHERE NOT EXISTS
+    ps.setBytes(6, row.jobID.bytes)
+    ps.setLong(7, row.userID)
   }
 }


### PR DESCRIPTION
Ticket #147 part 2

Adjusts the user-to-job link insert query to be an "insert if not exists" query.  This should resolve the 500s we are getting when multiple requests try and cause a user link insert at the same time.

Resolves #147 