### PR TITLE
Use the 8-debian tag and use apt-get over apt

### DIFF
--- a/databases/queue/Dockerfile
+++ b/databases/queue/Dockerfile
@@ -1,7 +1,7 @@
-FROM mysql:8
+FROM mysql:8-debian
 
-RUN apt update \
- && apt install -y expect \
+RUN apt-get update \
+ && apt-get install -y expect \
  && rm -rf /var/lib/apt/lists*
 
 COPY ./ddl /docker-entrypoint-initdb.d/


### PR DESCRIPTION
It appears the `mysql:8` image is no longer based on Debian, so this patch moves it to `mysql:8-debian`. In addition, `apt` is an end-user tool, while `apt-get` is more appropriate for scripts.