### PR TITLE
Use MariaDB instead of Oracle's MySQL

### DIFF
--- a/databases/queue/Dockerfile
+++ b/databases/queue/Dockerfile
@@ -1,7 +1,7 @@
-FROM mysql:8
+FROM mysql:8-debian
 
-RUN apt update \
- && apt install -y expect \
+RUN apt-get update \
+ && apt-get install -y expect \
  && rm -rf /var/lib/apt/lists*
 
 COPY ./ddl /docker-entrypoint-initdb.d/

--- a/databases/queue/Dockerfile
+++ b/databases/queue/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:8-debian
+FROM mariadb:10-jammy
 
 RUN apt-get update \
  && apt-get install -y expect \


### PR DESCRIPTION
The MySQL docker image is Oracle’s MySQL, which is undesirable. Per Bob B. and I, it is preferred if we could move this to the MariaDB image going forward.