### PR TITLE
Database Operations

### DIFF
--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/BasicQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/BasicQueryConfig.kt
@@ -1,0 +1,84 @@
+package org.veupathdb.service.mblast.query.model
+
+import org.veupathdb.lib.blast.Blast
+import org.veupathdb.lib.blast.common.BlastQueryBase
+import org.veupathdb.lib.hash_id.HashID
+import org.veupathdb.lib.jackson.Json
+import java.io.File
+import java.io.Reader
+
+/**
+ * # Basic Query Configuration
+ *
+ * Details describing a query job.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/Foxcapades
+ * @since  2.0.0
+ */
+interface BasicQueryConfig : AutoCloseable {
+
+  /**
+   * The Job ID of the query job this config represents.
+   */
+  val queryJobID: HashID
+
+  /**
+   * The target project/site.
+   */
+  val projectID:  String
+
+  /**
+   * Handle on the config file in the filesystem.
+   */
+  val configFile: File
+
+  /**
+   * Handle on the query file in the filesystem.
+   */
+  val queryFile: File
+
+  /**
+   * Returns a stream over the raw FASTA query.
+   */
+  fun getQueryReader(): Reader
+
+  /**
+   * Returns a stream over the raw JSON BLAST+ tool configuration.
+   */
+  fun getConfigReader(): Reader
+
+  /**
+   * Loads the BLAST+ tool configuration into memory and returns it.
+   */
+  fun getConfig(): BlastQueryBase
+
+  /**
+   * Loads the raw FASTA query into memory and returns it.
+   */
+  fun getQuery(): String
+
+  /**
+   * Releases/clears the resources backing this [BasicQueryConfig] instance.
+   */
+  override fun close()
+}
+
+data class BasicQueryConfigImpl(
+  override val queryJobID: HashID,
+  override val projectID: String,
+  override val configFile: File,
+  override val queryFile: File
+) : BasicQueryConfig {
+  override fun getQueryReader() = queryFile.reader()
+
+  override fun getConfigReader() = configFile.reader()
+
+  override fun getConfig() = configFile.inputStream().use { Blast.of(Json.parse(it)) as BlastQueryBase }
+
+  override fun getQuery() = configFile.readText()
+
+  override fun close() {
+    configFile.delete()
+    queryFile.delete()
+  }
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/BlastTarget.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/BlastTarget.kt
@@ -1,0 +1,18 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # BLAST Target Database
+ *
+ * Represents a target database for a BLAST query.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ * @since  2.0.0
+ *
+ * @constructor Constructs a new `BlastTarget` instance.
+ *
+ * @param displayName Display name / target category name.  Typically, the name
+ * of an organism.
+ *
+ * @param fileName Name of the blast database (without a file extension).
+ */
+data class BlastTarget(val displayName: String, val fileName: String)

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullParentQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullParentQueryConfig.kt
@@ -1,0 +1,17 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # Full Parent Query Config
+ *
+ * A [FullQueryConfig] implementation that includes a list of sub-jobs.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ * @since  2.0.0
+ */
+sealed interface FullParentQueryConfig : FullQueryConfig, ParentQueryConfig
+
+data class FullParentQueryConfigImpl(
+  val queryConfig: BasicQueryConfig,
+  override val targets: List<BlastTarget>,
+  override val childJobs: List<BasicQueryConfig>
+) : BasicQueryConfig by queryConfig, FullParentQueryConfig

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullParentUserQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullParentUserQueryConfig.kt
@@ -1,0 +1,34 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # Full Parent User Query Configuration
+ *
+ * A [FullUserQueryConfig] instance with the addition of a collection of all the
+ * sub job configurations.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/Foxcapades
+ * @since  2.0.0
+ */
+interface FullParentUserQueryConfig : FullUserQueryConfig, FullParentQueryConfig
+
+data class FullParentUserQueryConfigImpl(
+  val queryConfig: BasicQueryConfig,
+  val userMeta: QueryUserMeta,
+  override val targets: List<BlastTarget>,
+  override val childJobs: List<BasicQueryConfig>
+)
+  : BasicQueryConfig by queryConfig
+  , QueryUserMeta by userMeta
+  , FullParentUserQueryConfig
+{
+  constructor(
+    userConfig: UserQueryConfig,
+    links: List<BlastTarget>,
+    childJobs: List<BasicQueryConfig>
+  ) : this(
+    userConfig,
+    userConfig,
+    links,
+    childJobs
+  )
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullQueryConfig.kt
@@ -1,0 +1,25 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # Full Query Config
+ *
+ * A full query configuration is a configuration instance that contains enough
+ * detail to execute a query job.
+ *
+ * This differs from the [BasicQueryConfig] instance in that it also includes
+ * the BLAST+ query targets which are required in order to execute the BLAST+
+ * tool.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/Foxcapades
+ * @since  2.0.0
+ */
+interface FullQueryConfig : BasicQueryConfig {
+  /**
+   * The list of query targets for this config.
+   */
+  val targets: List<BlastTarget>
+}
+
+data class FullQueryConfigImpl(val queryConfig: BasicQueryConfig, override val targets: List<BlastTarget>)
+  : BasicQueryConfig by queryConfig
+  , FullQueryConfig

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullUserQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/FullUserQueryConfig.kt
@@ -1,0 +1,9 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # Full User Query Config
+ *
+ * Hybrid of a [UserQueryConfig] and a [FullQueryConfig].
+ */
+interface FullUserQueryConfig : UserQueryConfig, FullQueryConfig
+

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/ParentQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/ParentQueryConfig.kt
@@ -1,0 +1,14 @@
+package org.veupathdb.service.mblast.query.model
+
+sealed interface ParentQueryConfig : BasicQueryConfig {
+  /**
+   * Child jobs wrapping individual sequences from this parent job.
+   *
+   * If this parent job contains only a single sequence, this list will be
+   * empty.
+   *
+   * Entries in this list can be safely assumed to have the same user summary,
+   * user description, and list of BLAST+ query targets as the parent config.
+   */
+  val childJobs: List<BasicQueryConfig>
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/QueryUserMeta.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/QueryUserMeta.kt
@@ -1,0 +1,33 @@
+package org.veupathdb.service.mblast.query.model
+
+/**
+ * # Query Job User Metadata
+ *
+ * User metadata attached to a BLAST query job.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ * @since  2.0.0
+ */
+interface QueryUserMeta {
+
+  /**
+   * ID of the user attached to the query job.
+   */
+  val userID:      Long
+
+  /**
+   * Optional short summary provided by the user for the query job.
+   */
+  val summary:     String?
+
+  /**
+   * Optional long description provided by the user for the query job.
+   */
+  val description: String?
+}
+
+data class QueryUserMetaImpl(
+  override val userID:      Long,
+  override val summary:     String?,
+  override val description: String?
+) : QueryUserMeta

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/UserQueryConfig.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/model/UserQueryConfig.kt
@@ -1,0 +1,8 @@
+package org.veupathdb.service.mblast.query.model
+
+interface UserQueryConfig : BasicQueryConfig, QueryUserMeta
+
+data class UserQueryConfigImpl(val queryConfig: BasicQueryConfig, val userMeta: QueryUserMeta)
+  : BasicQueryConfig by queryConfig
+  , QueryUserMeta by userMeta
+  , UserQueryConfig

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/JobDBManager.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/JobDBManager.kt
@@ -1,0 +1,86 @@
+package org.veupathdb.service.mblast.query.sql
+
+import org.veupathdb.lib.container.jaxrs.utils.db.DbManager
+import org.veupathdb.lib.hash_id.HashID
+
+/**
+ * Job Database Manager
+ *
+ * Provides convenience methods for single queries against the database and
+ * a session context in which multiple operations may be performed.
+ *
+ * @see JobDBTransaction
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ * @since  2.0.0
+ */
+object JobDBManager {
+
+  /**
+   * Fetches a `FullParentQueryConfig` from the database for the given job ID if
+   * such a record exists.
+   *
+   * If the target record does not exist, this method returns `null`.
+   *
+   * @param queryJobID ID of the job config to fetch.
+   *
+   * @return Either the full job record, if it exists, or `null` if it does not.
+   */
+  fun getFullJob(queryJobID: HashID) =
+    JobDBTransaction(getConnection()).use { it.getFullJob(queryJobID)  }
+
+  /**
+   * Fetches a `FullParentUserQueryConfig` from the database for the given
+   * combination of job ID and user ID, if such a record exists.
+   *
+   * If the target job does not exist, or is not linked to the target user, this
+   * method returns `null`.
+   *
+   * @param queryJobID ID of the job config to fetch.
+   *
+   * @param userID ID of the user who the job must be linked to.
+   *
+   * @return Either the full job record including user metadata, or `null` if
+   * no such record exists.
+   */
+  fun getFullUserJob(queryJobID: HashID, userID: Long) =
+    JobDBTransaction(getConnection()).use { it.getFullUserJob(queryJobID, userID) }
+
+  /**
+   * Fetches a list of `FullParentUserQueryConfig`s from the database for the
+   * given user ID.
+   *
+   * @param userID ID of the user whose job configs should be fetched.
+   *
+   * @return A list of zero or more job configs linked to the target user.
+   */
+  fun getFullUserJobs(userID: Long) =
+    JobDBTransaction(getConnection()).use { it.getFullUserJobs(userID) }
+
+  /**
+   * Deletes the target link between a user and a query job.
+   *
+   * @param queryJobID ID of the job from which the link should be deleted.
+   *
+   * @param userID ID of the user whose link should be deleted.
+   */
+  fun deleteUserLink(queryJobID: HashID, userID: Long) =
+    JobDBTransaction(getConnection()).use { it.deleteUserLink(queryJobID, userID) }
+
+  /**
+   * Executes the given function in the context of a database transaction that
+   * will be committed on successful return.
+   *
+   * If the given function throws an exception, the transaction will be rolled
+   * back.
+   *
+   * @param fn Function to execute.
+   */
+  fun withTransaction(fn: (JobDBTransaction) -> Unit) =
+    JobDBTransaction(getConnection()).use(fn)
+
+  private fun getConnection() = DbManager.userDatabase()
+    .dataSource
+    .connection
+}
+

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/JobDBTransaction.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/JobDBTransaction.kt
@@ -1,0 +1,193 @@
+package org.veupathdb.service.mblast.query.sql
+
+import org.veupathdb.lib.hash_id.HashID
+import org.veupathdb.service.mblast.query.model.*
+import org.veupathdb.service.mblast.query.sql.queries.*
+import java.sql.Connection
+
+/**
+ * # Job DB Transaction Wrapped Operations
+ *
+ * Provides a collection of operations that may be performed on the job database
+ * in a database transaction.
+ *
+ * The transaction must be either committed or rolled back when done.
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ * @since  2.0.0
+ */
+class JobDBTransaction(private val con: Connection) : AutoCloseable {
+
+  init {
+    con.autoCommit = false
+  }
+
+  /**
+   * Inserts a query configuration into the database.
+   *
+   * @param config Config to insert.
+   */
+  fun insertQueryConfig(config: BasicQueryConfig) {
+    con.insertQueryConfig(config)
+  }
+
+  /**
+   * Inserts BLAST-target links for a target job.
+   *
+   * @param queryJobID ID of the job for which the BLAST-target links should be
+   * inserted.
+   *
+   * @param targets BLAST-target links to insert.
+   */
+  fun insertTargetLinks(queryJobID: HashID, targets: List<BlastTarget>) {
+    con.insertJobTargetLinks(queryJobID, targets)
+  }
+
+  /**
+   * Inserts user meta for a target job.
+   *
+   * @param queryJobID ID of the job for which user metadata should be inserted.
+   *
+   * @param meta User metadata to insert.
+   */
+  fun insertUserLink(queryJobID: HashID, meta: QueryUserMeta) {
+    con.insertUserLink(queryJobID, meta)
+  }
+
+  /**
+   * Updates the user meta for a target job.
+   *
+   * @param queryJobID ID of the job for which the user metadata should be
+   * updated.
+   *
+   * @param meta User metadata to update with.
+   */
+  fun updateUserMeta(queryJobID: HashID, meta: QueryUserMeta) {
+    con.updateUserLink(queryJobID, meta)
+  }
+
+  /**
+   * Fetches a [FullParentQueryConfig] for a target job if that job exists.
+   *
+   * @param queryJobID ID of the target job to fetch.
+   *
+   * @return Either the target job config, or `null` if the target job was not
+   * found.
+   */
+  fun getFullJob(queryJobID: HashID): FullParentQueryConfig? {
+    val parent   = con.selectQueryConfigByID(queryJobID) ?: return null
+    val targets  = con.selectQueryTargetsByJob(queryJobID)
+    val children = con.selectChildQueriesByParent(queryJobID)
+
+    if (targets.isEmpty())
+      throw IllegalStateException("Job $queryJobID has no targets!")
+
+    return FullParentQueryConfigImpl(parent, targets, children)
+  }
+
+  /**
+   * Fetches a [FullParentUserQueryConfig] for a target job and user if the job
+   * exists and the user is linked to it.
+   *
+   * @param queryJobID ID of the target job to fetch.
+   *
+   * @param userID ID of the user who must be linked to the target job.
+   *
+   * @return Either the target job config and user metadata or `null` if the
+   * target job was not found or was not linked to the target user.
+   */
+  fun getFullUserJob(queryJobID: HashID, userID: Long): FullParentUserQueryConfig? {
+    val parent   = con.selectQueryConfigByJobAndUser(queryJobID, userID) ?: return null
+    val targets  = con.selectQueryTargetsByJob(queryJobID)
+    val children = con.selectChildQueriesByParent(queryJobID)
+
+    if (targets.isEmpty())
+      throw IllegalStateException("Job $queryJobID has no targets!")
+
+    return FullParentUserQueryConfigImpl(parent, targets, children)
+  }
+
+  /**
+   * Fetches all the [FullParentUserQueryConfig] records linked to a target
+   * user.
+   *
+   * @param userID ID of the user whose jobs should be fetched.
+   *
+   * @return A list of zero or more job configuration records.
+   */
+  fun getFullUserJobs(userID: Long): List<FullParentUserQueryConfig> {
+    val parents  = con.selectQueriesByUser(userID)
+    val targets  = con.selectQueryTargetsByUser(userID)
+    val children = con.selectChildQueriesByUser(userID)
+
+    return parents.map {
+      val curTargets  = targets[it.queryJobID]
+      val curChildren = children[it.queryJobID] ?: emptyList()
+
+      if (curTargets.isNullOrEmpty())
+        throw IllegalStateException("Job ${it.queryJobID} has no targets!")
+
+      FullParentUserQueryConfigImpl(it, curTargets, curChildren)
+    }
+  }
+
+  /**
+   * Deletes the link between a target job and user.
+   *
+   * @param queryJobID ID of the target job.
+   *
+   * @param userID ID of the user whose link should be deleted.
+   */
+  fun deleteUserLink(queryJobID: HashID, userID: Long) {
+    con.deleteUserLink(queryJobID, userID)
+  }
+
+  /**
+   * Commits this transaction.
+   */
+  fun commit() {
+    con.commit()
+  }
+
+  /**
+   * Rolls this transaction back.
+   */
+  fun rollback() {
+    con.rollback()
+  }
+
+  /**
+   * Closes this transaction and it's underlying database connection.
+   */
+  override fun close() {
+    con.close()
+  }
+
+  /**
+   * Uses this transaction as the context in which the given function will be
+   * executed.
+   *
+   * Upon successful return from the function, the transaction will be committed
+   * and closed.
+   *
+   * On exception, the transaction will be rolled back and closed.
+   *
+   * @param fn Function to execute in this transaction.
+   *
+   * @param R Return type of the given function.
+   *
+   * @return The value returned by the given function.
+   */
+  inline fun <R> use(fn: (JobDBTransaction) -> R): R {
+    try {
+      val ret = fn(this)
+      commit()
+      return ret
+    } catch (e: Exception) {
+      rollback()
+      throw e
+    } finally {
+      close()
+    }
+  }
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/constants.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/constants.kt
@@ -1,0 +1,30 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+// ORA-00001
+const val ORA_CODE_UNIQUE_VIOLATION = 1
+
+object Schema {
+  const val MBlast = "mblast"
+}
+
+object Table {
+  const val QueryConfigs   = "query_configs"
+  const val QueryToQueries = "query_to_subqueries"
+  const val QueryToTargets = "query_to_targets"
+  const val QueryToUsers   = "query_to_users"
+}
+
+object Column {
+  const val ChildJobID  = "child_job_id"
+  const val Config      = "config"
+  const val Description = "description"
+  const val ParentJobID = "parent_job_id"
+  const val Position    = "position"
+  const val ProjectID   = "project_id"
+  const val Query       = "query"
+  const val QueryJobID  = "query_job_id"
+  const val Summary     = "summary"
+  const val TargetFile  = "target_file"
+  const val TargetName  = "target_name"
+  const val UserID      = "user_id"
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/delete-user-link.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/delete-user-link.kt
@@ -1,0 +1,27 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+DELETE FROM
+  ${Schema.MBlast}.${Table.QueryToUsers}
+WHERE
+  ${Column.QueryJobID} = ?
+  AND ${Column.UserID} = ?
+"""
+
+/**
+ * Deletes the link between a target user and target query job.
+ *
+ * @param queryJobID ID of the job the user link should be removed from.
+ *
+ * @param userID ID of the user whose link should be removed.
+ */
+fun Connection.deleteUserLink(queryJobID: HashID, userID: Long) {
+  prepareStatement(SQL).use { ps ->
+    ps.setString(1, queryJobID.string)
+    ps.setLong(2, userID)
+    ps.execute()
+  }
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-child-links.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-child-links.kt
@@ -1,0 +1,54 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.sql.util.insertBatchWithRaceCheck
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+INSERT INTO
+  ${Schema.MBlast}.${Table.QueryToQueries} (
+    ${Column.ParentJobID}
+  , ${Column.ChildJobID}
+  , ${Column.Position}
+  )
+VALUES
+  (?, ?, ?)
+"""
+
+/**
+ * Inserts links between the given parent job and all the given child jobs in
+ * the order they appear in the given `Iterable`.
+ *
+ * All job IDs that are given to this method (parent and child IDs) must already
+ * exist in the database.
+ *
+ * If a unique constraint violation occurs while attempting to insert this
+ * record, then it is most likely a race condition caused by the client/user
+ * double submitting the job.  This function will handle that case and return
+ * either `true` if the rows were successfully inserted, or `false` if the
+ * records already existed.
+ *
+ * @receiver Connection/transaction the query will be executed on.
+ *
+ * @param parentJobID Parent job that the child jobs will be linked to.
+ *
+ * @param childJobIDs An ordered `Iterable` containing the IDs of the jobs to
+ * link the parent job to.
+ *
+ * @return `true` if the links were successfully inserted into the database, or
+ * `false` if the records already existed.
+ */
+fun Connection.insertChildJobLinks(parentJobID: HashID, childJobIDs: Iterable<HashID>) {
+  prepareStatement(SQL).use { ps ->
+    childJobIDs.forEachIndexed { i, it ->
+      ps.setString(1, parentJobID.string)
+      ps.setString(2, it.string)
+      ps.setInt(3, i)
+
+      ps.addBatch()
+      ps.clearParameters()
+    }
+
+    ps.insertBatchWithRaceCheck()
+  }
+}

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-query-config.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-query-config.kt
@@ -1,0 +1,56 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.model.BasicQueryConfig
+import org.veupathdb.service.mblast.query.sql.util.insertWithRaceCheck
+import java.sql.Connection
+import java.sql.SQLException
+
+private const val SQL = """
+INSERT INTO
+  ${Schema.MBlast}.${Table.QueryConfigs} (
+    ${Column.QueryJobID}
+  , ${Column.ProjectID}
+  , ${Column.Config}
+  , ${Column.Query}
+  )
+VALUES
+  (?, ?, ?, ?)
+"""
+
+/**
+ * Inserts a new query configuration record into the permanent store database.
+ *
+ * If a unique constraint violation occurs while attempting to insert this
+ * record, then it is most likely a race condition caused by the client/user
+ * double submitting the job.  This function will handle that case and return
+ * either `true` if the row was successfully inserted, or `false` if the record
+ * already existed.
+ *
+ * @param config Basic configuration to insert into the database.
+ *
+ * @receiver Connection/transaction that this query will be executed on.
+ *
+ * @return `true` if a new record was inserted by this call.  `false` if there
+ * was a unique constraint violation caused by this record insertion (meaning
+ * the record already exists).
+ *
+ * @throws SQLException If an error occurs while attempting to execute this
+ * query against the database.
+ */
+fun Connection.insertQueryConfig(config: BasicQueryConfig) =
+  prepareStatement(SQL).use {
+    val cReader = config.getConfigReader()
+    val qReader = config.getQueryReader()
+
+    it.setString(1, config.queryJobID.string)
+    it.setString(2, config.projectID)
+    it.setClob(3, cReader)
+    it.setClob(4, qReader)
+
+    try {
+      it.insertWithRaceCheck()
+    } finally {
+      cReader.close()
+      qReader.close()
+    }
+  }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-target-links.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-target-links.kt
@@ -1,0 +1,48 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.model.BlastTarget
+import org.veupathdb.service.mblast.query.sql.util.insertBatchWithRaceCheck
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+INSERT INTO
+  ${Schema.MBlast}.${Table.QueryToTargets} (
+    ${Column.QueryJobID}
+  , ${Column.TargetName}
+  , ${Column.TargetFile}
+  )
+VALUES
+  (?, ?, ?)
+"""
+
+/**
+ * Inserts a list of BLAST query targets into the database, linked to a target
+ * job.
+ *
+ * If a unique constraint violation occurs while attempting to insert this
+ * record, then it is most likely a race condition caused by the client/user
+ * double submitting the job.  This function will handle that case and return
+ * either `true` if the row was successfully inserted, or `false` if the record
+ * already existed.
+ *
+ * @param jobID ID of the target query job the targets will be linked to.
+ *
+ * @param targets Targets to be inserted.
+ *
+ * @return `true` if the record was successfully inserted. `false` if the record
+ * already existed.
+ */
+fun Connection.insertJobTargetLinks(jobID: HashID, targets: Iterable<BlastTarget>) =
+  prepareStatement(SQL).use { ps ->
+    targets.forEach {
+      ps.setString(1, jobID.string)
+      ps.setString(2, it.displayName)
+      ps.setString(3, it.fileName)
+
+      ps.addBatch()
+      ps.clearParameters()
+    }
+
+    ps.insertBatchWithRaceCheck()
+  }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-user-links.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/insert-user-links.kt
@@ -1,0 +1,44 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.model.QueryUserMeta
+import org.veupathdb.service.mblast.query.sql.util.insertWithRaceCheck
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+
+private const val SQL = """
+INSERT INTO
+  ${Schema.MBlast}.${Table.QueryToUsers} (
+    ${Column.QueryJobID}
+  , ${Column.UserID}
+  , ${Column.Summary}
+  , ${Column.Description}
+  )
+VALUES
+  (?, ?, ?, ?)
+"""
+
+/**
+ * Inserts a link and user metadata for a user and target query job.
+ *
+ * If a unique constraint violation occurs while attempting to insert this
+ * record, then it is most likely a race condition caused by the client/user
+ * double submitting the job.  This function will handle that case and return
+ * either `true` if the row was successfully inserted, or `false` if the record
+ * already existed.
+ *
+ * @param queryJobID ID of the target query job the user will be linked to.
+ *
+ * @param meta User metadata that will be inserted.
+ *
+ * @return `true` if the record was successfully inserted. `false` if the record
+ * already existed.
+ */
+fun Connection.insertUserLink(queryJobID: HashID, meta: QueryUserMeta) =
+  prepareStatement(SQL).use { ps ->
+    ps.setString(1, queryJobID.string)
+    ps.setLong(2, meta.userID)
+    ps.setString(3, meta.summary)
+    ps.setClob(4, meta.description?.reader())
+
+    ps.insertWithRaceCheck()
+  }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/select-query-config.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/select-query-config.kt
@@ -1,0 +1,260 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.sql.util.clobToFile
+import org.veupathdb.service.mblast.query.sql.util.fetchList
+import org.veupathdb.service.mblast.query.sql.util.fetchOpt
+import org.veupathdb.lib.hash_id.HashID
+import org.veupathdb.service.mblast.query.model.BasicQueryConfig
+import org.veupathdb.service.mblast.query.model.BasicQueryConfigImpl
+import org.veupathdb.service.mblast.query.model.QueryUserMetaImpl
+import org.veupathdb.service.mblast.query.model.UserQueryConfigImpl
+import java.sql.Connection
+import java.sql.ResultSet
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Select Job By Job ID
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+private const val SQL_BY_ID = """
+SELECT
+  ${Column.QueryJobID}
+, ${Column.ProjectID}
+, ${Column.Config}
+, ${Column.Query}
+FROM
+  ${Schema.MBlast}.${Table.QueryConfigs}
+WHERE
+  ${Column.QueryJobID} = ?
+"""
+
+/**
+ * Retrieves a target BLAST query configuration from the database.
+ *
+ * @param jobID ID of the job whose query configuration should be fetched.
+ *
+ * @return Either the query configuration with the given job ID, or null if no
+ * matching record exists.
+ */
+fun Connection.selectQueryConfigByID(jobID: HashID) =
+  prepareStatement(SQL_BY_ID).use { ps ->
+    ps.setString(1, jobID.string)
+    ps.fetchOpt { parseQueryConfig() }
+  }
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Select Jobs By User ID
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+private const val SQL_BY_USER = """
+SELECT
+  a.${Column.QueryJobID}
+, a.${Column.ProjectID}
+, a.${Column.Config} 
+, a.${Column.Query}
+, b.${Column.UserID}
+, b.${Column.Summary}
+, b.${Column.Description}
+FROM
+  ${Schema.MBlast}.${Table.QueryConfigs} a
+  INNER JOIN ${Schema.MBlast}.${Table.QueryToUsers} b
+    ON a.${Column.QueryJobID} = b.${Column.QueryJobID}
+WHERE
+  b.${Column.UserID} = ?
+"""
+
+/**
+ * Retrieves a list of configurations for BLAST queries that are linked to a
+ * target user.
+ *
+ * @param userID ID of the user whose query configs should be fetched.
+ *
+ * @return A list of zero or more query configurations.
+ */
+fun Connection.selectQueriesByUser(userID: Long) =
+  prepareStatement(SQL_BY_USER).use { ps ->
+    ps.setLong(1, userID)
+    ps.fetchList { parseUserQueryRecord() }
+  }
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Select Jobs By User ID and Job ID
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+private const val SQL_BY_ID_AND_USER = """
+SELECT
+  a.${Column.QueryJobID}
+, a.${Column.ProjectID}
+, a.${Column.Config} 
+, a.${Column.Query}
+, b.${Column.UserID}
+, b.${Column.Summary}
+, b.${Column.Description}
+FROM
+  ${Schema.MBlast}.${Table.QueryConfigs} a
+  INNER JOIN ${Schema.MBlast}.${Table.QueryToUsers} b
+    ON a.${Column.QueryJobID} = b.${Column.QueryJobID}
+WHERE
+  b.${Column.UserID} = ?
+  AND a.${Column.QueryJobID} = ?
+"""
+
+/**
+ * Retrieves a target job that is linked to a target user.
+ *
+ * If the target job does not exist, or is not linked to the target user, this
+ * method returns `null`.
+ *
+ * @param queryJobID ID of the job whose query config should be fetched.
+ *
+ * @param userID ID of the user who must be linked to the target job.
+ *
+ * @return Either the target job query configuration or `null`.
+ */
+fun Connection.selectQueryConfigByJobAndUser(queryJobID: HashID, userID: Long) =
+  prepareStatement(SQL_BY_ID_AND_USER).use { ps ->
+    ps.setLong(1, userID)
+    ps.setString(2, queryJobID.string)
+    ps.fetchOpt { parseUserQueryRecord() }
+  }
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Select Jobs By Parent ID
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Query to select child blast job configurations by user ID.
+ *
+ * This query gets the set of parent jobs by user ID from the user links table
+ * then uses that set to get the list of blast configurations that are marked as
+ * children under the set of parent jobs.
+ */
+private const val SQL_CHILDREN_BY_USER = """
+SELECT
+  a.${Column.QueryJobID}
+, a.${Column.ProjectID}
+, a.${Column.Config}
+, a.${Column.Query}
+, b.${Column.ParentJobID}
+FROM
+  ${Schema.MBlast}.${Table.QueryConfigs} a
+  INNER JOIN ${Schema.MBlast}.${Table.QueryToQueries} b
+    ON a.${Column.QueryJobID} = b.${Column.ChildJobID}
+WHERE
+  b.${Column.ParentJobID} IN (
+    SELECT
+      ${Column.QueryJobID}
+    FROM
+      ${Schema.MBlast}.${Table.QueryToUsers}
+    WHERE
+      ${Column.UserID} = ?
+  )
+"""
+
+/**
+ * Retrieves a map of job ID to list of child job query configurations attached
+ * to a target user.
+ *
+ * @param userID ID of the user whose total child job set should be retrieved.
+ *
+ * @return A map of parent job ID to list of child query job configs under that
+ * parent job.
+ */
+fun Connection.selectChildQueriesByUser(userID: Long) =
+  prepareStatement(SQL_CHILDREN_BY_USER).use { ps ->
+    ps.setLong(1, userID)
+    ps.executeQuery().use { it.parseChildConfigMap() }
+  }
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Select Jobs By Parent ID
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+private const val SQL_CHILDREN_BY_PARENT = """
+SELECT
+  ${Column.QueryJobID}
+, ${Column.ProjectID}
+, ${Column.Config}
+, ${Column.Query}
+FROM
+  ${Schema.MBlast}.${Table.QueryConfigs}
+WHERE
+  ${Column.QueryJobID} IN (
+    SELECT
+      ${Column.ChildJobID}
+    FROM
+      ${Schema.MBlast}.${Table.QueryToQueries}
+    WHERE
+      ${Column.ParentJobID} = ?
+  )
+"""
+
+/**
+ * Retrieves a list of child job query configurations for a target parent job.
+ *
+ * If no job exists with the given job ID, an empty list will be returned.
+ *
+ * @param queryJobID ID of the target parent job whose child jobs should be
+ * fetched.
+ *
+ * @return A list of zero or more child jobs linked to the given parent job ID.
+ */
+fun Connection.selectChildQueriesByParent(queryJobID: HashID) =
+  prepareStatement(SQL_CHILDREN_BY_PARENT).use { ps ->
+    ps.setString(1, queryJobID.string)
+    ps.fetchList { parseQueryConfig() }
+  }
+
+// ---------------------------------------------------------------------------------------------------------------------
+//
+// -- Result Parsing
+//
+// ---------------------------------------------------------------------------------------------------------------------
+
+/**
+ * Parses a [BasicQueryConfig] instance from the receiver [ResultSet].
+ *
+ * This method requires that the `ResultSet` cursor is already on a row that can
+ * be parsed.
+ *
+ * @receiver ResultSet from which a row will be parsed.
+ *
+ * @return A parsed `BasicQueryConfig` instance.
+ */
+private fun ResultSet.parseQueryConfig(): BasicQueryConfig =
+  BasicQueryConfigImpl(
+    HashID(getString(Column.QueryJobID)),
+    getString(Column.ProjectID),
+    clobToFile(Column.Config),
+    clobToFile(Column.Query),
+  )
+
+private fun ResultSet.parseUserQueryRecord() =
+  UserQueryConfigImpl(
+    parseQueryConfig(),
+    QueryUserMetaImpl(
+      getLong(Column.UserID),
+      getString(Column.Summary),
+      getString(Column.Description)
+    )
+  )
+
+private fun ResultSet.parseChildConfigMap(): Map<HashID, List<BasicQueryConfig>> =
+  HashMap<HashID, MutableList<BasicQueryConfig>>(8).also {
+    while (next())
+      it.computeIfAbsent(HashID(getString(Column.ParentJobID))) { ArrayList(8) }
+        .add(parseQueryConfig())
+  }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/select-query-targets.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/select-query-targets.kt
@@ -1,0 +1,78 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.service.mblast.query.model.BlastTarget
+import org.veupathdb.lib.hash_id.HashID
+import java.sql.Connection
+import java.sql.ResultSet
+
+private const val SQL_SINGLE = """
+SELECT
+  ${Column.QueryJobID}
+, ${Column.TargetName}
+, ${Column.TargetFile}
+FROM
+  ${Schema.MBlast}.${Table.QueryToTargets}
+WHERE
+  ${Column.QueryJobID} = ?
+"""
+
+private const val SQL_BULK = """
+SELECT
+  ${Column.QueryJobID}
+, ${Column.TargetName}
+, ${Column.TargetFile}
+FROM
+  ${Schema.MBlast}.${Table.QueryToTargets}
+WHERE
+  ${Column.QueryJobID} IN (
+    SELECT
+      ${Column.QueryJobID}
+    FROM
+      ${Schema.MBlast}.${Table.QueryToUsers}
+    WHERE
+      ${Column.UserID} = ?
+  )
+"""
+
+/**
+ * Retrieves the list of BLAST targets attached to the target job record.
+ *
+ * @param jobID ID of the query job whose BLAST targets should be fetched.
+ *
+ * @return A list of BLAST targets for the target job.
+ */
+fun Connection.selectQueryTargetsByJob(jobID: HashID) =
+  prepareStatement(SQL_SINGLE).use { ps ->
+    ps.setString(1, jobID.string)
+    ps.executeQuery().use { it.parseQueryTargets() }
+  }
+
+/**
+ * Retrieves a map of job IDs to the lists of BLAST targets attached to the jobs
+ * with those IDs for a target user.
+ *
+ * @param userID ID of the user whose BLAST targets should be fetched.
+ *
+ * @return A map of job ID to list of BLAST targets for the job with that ID.
+ */
+fun Connection.selectQueryTargetsByUser(userID: Long) =
+  prepareStatement(SQL_BULK).use { ps ->
+    ps.setLong(1, userID)
+    ps.executeQuery().use { it.parseQueryTargetMap() }
+  }
+
+private fun ResultSet.parseQueryTargetMap(): Map<HashID, List<BlastTarget>> =
+  HashMap<HashID, ArrayList<BlastTarget>>().also {
+    while (next())
+      it.computeIfAbsent(HashID(getString(Column.QueryJobID))) { ArrayList(8) }
+        .add(parseQueryTarget())
+  }
+
+private fun ResultSet.parseQueryTargets(): List<BlastTarget> =
+  ArrayList<BlastTarget>(8).also {
+    while (next())
+      it.add(parseQueryTarget())
+  }
+
+private fun ResultSet.parseQueryTarget() =
+  BlastTarget(getString(Column.TargetName), getString(Column.TargetFile))

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/update-user-link.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/queries/update-user-link.kt
@@ -1,0 +1,33 @@
+package org.veupathdb.service.mblast.query.sql.queries
+
+import org.veupathdb.lib.hash_id.HashID
+import org.veupathdb.service.mblast.query.model.QueryUserMeta
+import java.sql.Connection
+
+private const val SQL = """
+UPDATE
+  ${Schema.MBlast}.${Table.QueryToUsers}
+SET
+  ${Column.Summary} = ?
+, ${Column.Description} = ?
+WHERE
+  ${Column.QueryJobID} = ?
+  AND ${Column.UserID} = ?
+"""
+
+/**
+ * Updates the metadata attached to a link between a query job and a user.
+ *
+ * @param queryJobID ID of the job for which the link will be updated.
+ *
+ * @param meta Metadata containing details about the link to update and it's new
+ * values.
+ */
+fun Connection.updateUserLink(queryJobID: HashID, meta: QueryUserMeta) =
+  prepareStatement(SQL).use { ps ->
+    ps.setString(1, meta.summary)
+    ps.setString(2, meta.description)
+    ps.setString(3, queryJobID.string)
+    ps.setLong(4, meta.userID)
+    ps.executeUpdate()
+  }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/util/prepared-statement.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/util/prepared-statement.kt
@@ -1,0 +1,90 @@
+package org.veupathdb.service.mblast.query.sql.util
+
+import org.veupathdb.service.mblast.query.sql.queries.ORA_CODE_UNIQUE_VIOLATION
+import java.sql.PreparedStatement
+import java.sql.ResultSet
+import java.sql.SQLException
+
+/**
+ * Executes the receiver statement and handles unique constraint violations.
+ *
+ * If the statement execution completes without exception, this method will
+ * return `true` indicating that the record was inserted successfully.
+ *
+ * If the statement execution throws a unique constraint violation error, this
+ * method will return `false` indicating that the record was not inserted as it
+ * already existed.
+ *
+ * If the statement execution throws a different exception, that exception will
+ * be rethrown.
+ *
+ * @receiver PreparedStatement that will be executed.
+ *
+ * @return `true` if the row was inserted successfully, `false` if the target
+ * record already existed.
+ */
+fun PreparedStatement.insertWithRaceCheck() =
+  try {
+    execute()
+    true
+  } catch (e: SQLException) {
+    if (e.errorCode == ORA_CODE_UNIQUE_VIOLATION)
+      false
+    else
+      throw e
+  }
+
+/**
+ * Executes the receiver statement and handles unique constraint violations.
+ *
+ * If the statement execution completes without exception, this method will
+ * return `true` indicating that the record was inserted successfully.
+ *
+ * If the statement execution throws a unique constraint violation error, this
+ * method will return `false` indicating that the record was not inserted as it
+ * already existed.
+ *
+ * If the statement execution throws a different exception, that exception will
+ * be rethrown.
+ *
+ * @receiver PreparedStatement that will be executed.
+ *
+ * @return `true` if the row was inserted successfully, `false` if the target
+ * record already existed.
+ */
+fun PreparedStatement.insertBatchWithRaceCheck() =
+  try {
+    executeBatch()
+    true
+  } catch (e: SQLException) {
+    if (e.errorCode == ORA_CODE_UNIQUE_VIOLATION)
+      false
+    else
+      throw e
+  }
+
+/**
+ * Executes the target query and fetches an optional return value based on
+ * whether the query had a result row.
+ *
+ * @receiver PreparedStatement instance that is ready to be executed.
+ *
+ * @param fn Mapping function that will be called only if the query succeeds and
+ * there is a row available in the query [ResultSet].
+ *
+ * @param T Type of the value that may be returned by the given function.
+ *
+ * @return Either an instance of [T] if there was a row available, or `null` if
+ * there were no rows available.
+ */
+inline fun <T> PreparedStatement.fetchOpt(fn: ResultSet.() -> T): T? =
+  executeQuery().use { it.opt(fn) }
+
+/**
+ * Executes the target query and fetches a list of zero or more values parsed
+ * from the rows in the query result.
+ *
+ * @R
+ */
+inline fun <T> PreparedStatement.fetchList(fn: ResultSet.() -> T): List<T> =
+  executeQuery().use { it.map(fn = fn) }

--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/util/result-set.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/sql/util/result-set.kt
@@ -1,0 +1,86 @@
+package org.veupathdb.service.mblast.query.sql.util
+
+import org.veupathdb.lib.mblast.utils.tmp.TempFiles
+import java.sql.ResultSet
+
+
+/**
+ * Parse optional value.
+ *
+ * If the `ResultSet` contains at least one row, this mixin function will index
+ * the `ResultSet` cursor to that row, call the given parsing function and
+ * pass back up the value returned by that function.
+ *
+ * If the `ResultSet` contains zero rows, this mixin function will simply return
+ * `null`.
+ *
+ * @receiver ResultSet on which the given parsing function will be called if
+ * there is at least one row present.
+ *
+ * @param fn Parsing function that will be called one time if and only if there
+ * is at least one row present in the receiver `ResultSet`.
+ *
+ * @param T Type of the value that will be returned by the given parsing
+ * function.
+ *
+ * @return The parsed value returned by [fn] if and only if there is at least
+ * one row available in the receiver `ResultSet`.  `null` if there are zero rows
+ * available in the receiver `ResultSet`.
+ */
+inline fun <T> ResultSet.opt(fn: ResultSet.() -> T) =
+  if (next())
+    fn()
+  else
+    null
+
+/**
+ * Map rows to values.
+ *
+ * Calls the given mapping function on each row available in the receiver
+ * `ResultSet` and collects the results in a list which is returned.
+ *
+ * If the receiver `ResultSet` does not have any rows available, the returned
+ * list will be empty.
+ *
+ * @receiver ResultSet on which the given parsing function will be called for
+ * each available result row.
+ *
+ * @param preSize Initial size of the list into which the parsed rows will be
+ * added.
+ *
+ * @param fn Parsing function that will be called for each row available in the
+ * `ResultSet`.
+ *
+ * @param T Type of the values that will be returned by the given parsing
+ * function.
+ *
+ * @return A list of values parsed from the receiver `ResultSet`.
+ */
+inline fun <T> ResultSet.map(preSize: Int = 8, fn: ResultSet.() -> T): List<T> =
+  ArrayList<T>(preSize).also {
+    while (next()) {
+      it.add(fn())
+    }
+  }
+
+/**
+ * Writes the CLOB value at the give column index out to a temp file then
+ * returns a handle on that file.
+ *
+ * **WARNING**: This method makes no attempt to verify whether the target CLOB
+ * column is `null`, and assumes that the value is not `null`.
+ *
+ * @param colLabel Column name of the CLOB data to write out to a temp file.
+ *
+ * @return A handle on a temp file containing the value read from the CLOB
+ * column at the given column index.
+ */
+fun ResultSet.clobToFile(colLabel: String) =
+  getClob(colLabel).characterStream.use { res ->
+    TempFiles.create().also {
+      it.bufferedWriter().use { wri ->
+        res.transferTo(wri)
+        wri.flush()
+      }
+    }
+  }


### PR DESCRIPTION
Adds two packages from the rewrite branch:

* `org.veupathdb.service.mblast.query.model`: The data types used when working internally in the mblast service.
* `org.veupathdb.service.mblast.query.sql`: The database operations that consume or produce those data types.

