### PR TITLE
Use DB_BUILD environment variable.

### DIFF
--- a/rest-service/src/main/kotlin/mb/lib/config/Config.kt
+++ b/rest-service/src/main/kotlin/mb/lib/config/Config.kt
@@ -212,4 +212,15 @@ object Config : Options() {
   var maxAASeqSize = 102_400
     private set
 
+  // ╠════════════════════════════════════════════════════════════════════════════════════════╣ //
+
+  @Option(
+    names = ["--db-build"],
+    arity = "1",
+    defaultValue = "\${env:DB_BUILD}",
+    description = ["Site DB build number"],
+    required = true,
+  )
+  var dbBuild = 60
+    private set
 }

--- a/rest-service/src/main/kotlin/mb/lib/path/index.kt
+++ b/rest-service/src/main/kotlin/mb/lib/path/index.kt
@@ -2,9 +2,9 @@
 package mb.lib.path
 
 import mb.lib.config.Config
-import java.io.File
 import java.util.*
 import java.util.stream.Stream
+import kotlin.io.path.Path
 
 fun findDBPath(site: String, organism: String, target: String): Optional<String> {
   val root = Config.dbMountPath
@@ -24,14 +24,14 @@ fun findDBPath(site: String, organism: String, target: String): Optional<String>
  * @return An array of zero or more builds available for the given [site].  If
  * the site is invalid, or no builds exist, an empty array will be returned.
  */
-fun findBuildVersionsFor(site: String): Stream<String> = File(Config.dbMountPath, site)
-  .takeIf(File::isDirectory)
-  ?.listFiles(File::isDirectory)
-  ?.let(Arrays::stream)
-  ?.map(File::getName)
-  ?.sorted(Comparator.reverseOrder())
-?:
-  Stream.empty()
+fun findBuildVersionsFor(site: String): Stream<String> =
+  Path(Config.dbMountPath, site, "build-${Config.dbBuild}").toFile()
+    .let {
+      if (it.exists())
+        Stream.of(it.name)
+      else
+        Stream.empty()
+    }
 
 /**
  * Attempts to locate the correct, possibly new Blast target DB path.


### PR DESCRIPTION
Rather than dynamically determining which build version to use when finding the path to a BLAST+ database file, use the configured build number value.