### PR TITLE
Logging OutputStream

### DIFF
--- a/lib-logging-output-stream/build.gradle.kts
+++ b/lib-logging-output-stream/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+  kotlin("jvm")
+  id("org.jetbrains.dokka") version "1.7.20"
+}
+
+repositories {
+  mavenCentral()
+}
+
+java {
+  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_1_8
+
+  withSourcesJar()
+  withJavadocJar()
+}
+
+tasks.dokkaHtml {
+  outputDirectory.set(rootDir.resolve("docs/dokka/logging-output-stream/$version"))
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}
+
+dependencies {
+  implementation("io.foxcapades.lib.kps:kpd:1.1.0")
+  implementation("io.k-libs:ubyte-ascii:1.0.0")
+}

--- a/lib-logging-output-stream/src/main/kotlin/org/veupathdb/lib/io/LoggingOutputStream.kt
+++ b/lib-logging-output-stream/src/main/kotlin/org/veupathdb/lib/io/LoggingOutputStream.kt
@@ -1,0 +1,69 @@
+package org.veupathdb.lib.io
+
+import io.foxcapades.lib.kps.kpd.UByteDeque
+import io.klibs.ascii.ubyte.ASCII_CR
+import io.klibs.ascii.ubyte.ASCII_LF
+import io.klibs.ascii.ubyte.ASCII_NUL
+import java.io.OutputStream
+
+/**
+ * OutputStream implementation that outputs lines of text to a logger function.
+ *
+ * **Example**
+ * ```
+ * // Some text to log
+ * val myText = """
+ * Hello
+ * Goodbye
+ * """
+ *
+ * // Create a log stream wrapping a logger method
+ * val logStream = LoggingOutputStream(logger::debug)
+ *
+ * // Pipe input stream to the logging output stream
+ * myText.byteInputStream().transferTo(logStream)
+ * ```
+ *
+ * @author Elizabeth Paige Harper - https://github.com/foxcapades
+ *
+ * @constructor Constructs a new `LoggingOutputStream` instance.
+ *
+ * @param logWriter Function that will be called with collected log lines.
+ */
+@Suppress("NOTHING_TO_INLINE")
+class LoggingOutputStream(private val logWriter: (line: String) -> Unit) : OutputStream() {
+  private val buffer = UByteDeque(256)
+
+  override fun write(b: Int) {
+    write(b.toUByte())
+  }
+
+  override fun flush() {
+    flushToLogger()
+  }
+
+  override fun close() {
+    flushToLogger()
+  }
+
+  private inline fun write(b: UByte) {
+    if (isLineBreak(b)) {
+      flushToLogger()
+    } else {
+      buffer += b
+    }
+  }
+
+  @OptIn(ExperimentalUnsignedTypes::class)
+  private inline fun flushToLogger() {
+    val bytes = UByteArray(buffer.size)
+
+    buffer.copyInto(bytes)
+    buffer.clear()
+
+    logWriter(bytes.asByteArray().decodeToString())
+  }
+
+  private inline fun isLineBreak(b: UByte)=
+    b == ASCII_LF || b == ASCII_CR || b == ASCII_NUL
+}

--- a/lib-logging-output-stream/src/main/kotlin/org/veupathdb/lib/io/LoggingOutputStream.kt
+++ b/lib-logging-output-stream/src/main/kotlin/org/veupathdb/lib/io/LoggingOutputStream.kt
@@ -56,12 +56,8 @@ class LoggingOutputStream(private val logWriter: (line: String) -> Unit) : Outpu
 
   @OptIn(ExperimentalUnsignedTypes::class)
   private inline fun flushToLogger() {
-    val bytes = UByteArray(buffer.size)
-
-    buffer.copyInto(bytes)
+    logWriter(buffer.toArray().asByteArray().decodeToString())
     buffer.clear()
-
-    logWriter(bytes.asByteArray().decodeToString())
   }
 
   private inline fun isLineBreak(b: UByte)=

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,9 +30,11 @@ project(":lib-blast-types").name = "blast-types"
 include(":lib-mblast-utils")
 include(":lib-temp-cache")
 include(":lib-blast-query-parser")
+include(":lib-logging-output-stream")
 
 include(":lib-jvm-mblast-sdk")
 project(":lib-jvm-mblast-sdk").name = "mblast-sdk"
+
 
 include(":script-mblast2-migration")
 include(":script-mblast-e2e")


### PR DESCRIPTION
Adds a single class helper library to be consumed by both the query and report service that provides an `OutputStream` implementation that outputs written data as log lines via a logging function.