### PR TITLE
Log stderr output from blast+ cli commands

### DIFF
--- a/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/jobs/BlastExecutor.kt
+++ b/service-query/src/main/kotlin/org/veupathdb/service/mblast/query/jobs/BlastExecutor.kt
@@ -1,5 +1,7 @@
 package org.veupathdb.service.mblast.query.jobs
 
+import mblast.util.io.LoggingOutputStream
+import mblast.util.io.TeeInputStream
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.ThreadContext
 import org.veupathdb.lib.blast.Blast
@@ -51,7 +53,7 @@ class BlastExecutor : JobExecutor {
     ) {
       // Write the stderr for the BLAST+ command out to file (which will be
       // persisted to S3)
-      ctx.workspace.write(Const.StdErrFileName, errorStream)
+      ctx.workspace.write(Const.StdErrFileName, TeeInputStream(errorStream, LoggingOutputStream(logger::warn), true))
       waitFor().also { timer.observeDuration() }
     }
 

--- a/service-report/build.gradle.kts
+++ b/service-report/build.gradle.kts
@@ -47,6 +47,8 @@ dependencies {
   implementation("org.gusdb:fgputil-core:2.7.4")
   implementation("org.gusdb:fgputil-db:2.7.4")
 
+  implementation(project(":lib-mblast-utils"))
+
   implementation("org.veupathdb.lib:jaxrs-container-core:6.11.0")
   implementation("org.veupathdb.lib:compute-platform:1.3.4")
   implementation("org.veupathdb.lib:hash-id:1.1.0")

--- a/service-report/src/main/kotlin/org/veupathdb/service/mblast/report/jobs/FormatExecutor.kt
+++ b/service-report/src/main/kotlin/org/veupathdb/service/mblast/report/jobs/FormatExecutor.kt
@@ -1,6 +1,8 @@
 package org.veupathdb.service.mblast.report.jobs
 
 import com.fasterxml.jackson.databind.node.ObjectNode
+import mblast.util.io.LoggingOutputStream
+import mblast.util.io.TeeInputStream
 import org.apache.logging.log4j.CloseableThreadContext
 import org.apache.logging.log4j.LogManager
 import org.veupathdb.lib.blast.Blast
@@ -102,7 +104,7 @@ class FormatExecutor : JobExecutor {
         .directory(ctx.workspace.path.toFile())
         .start()
     ) {
-      ctx.workspace.write(Const.STD_ERR_FILE_NAME, errorStream)
+      ctx.workspace.write(Const.STD_ERR_FILE_NAME, TeeInputStream(errorStream, LoggingOutputStream(logger::warn), true))
       waitFor().also { timer.observeDuration() }
     }
 


### PR DESCRIPTION
Tee the pipe from the process' stderr to also output to a log writer.

Resolves #199 