### PR TITLE
Validate first sequence line for too many dashes

### DIFF
--- a/lib-blast-query-parser/src/main/kotlin/mblast/query/validate/exceptions.kt
+++ b/lib-blast-query-parser/src/main/kotlin/mblast/query/validate/exceptions.kt
@@ -30,3 +30,6 @@ class SequenceTooLongException(
 
 class QueryTooLongException(val maxTotalLength: Int)
   : MBlastQueryParseException("The input query was longer than the max allowed query length of $maxTotalLength characters.")
+
+class TooManyDashesOnFirstLineException(val sequenceNumber: Int)
+  : MBlastQueryParseException("The first line of input sequence #$sequenceNumber contained too many dashes.")


### PR DESCRIPTION
Tested with the following sequences:


**Bad with Defline**
```
> foo bar
----------------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

**Bad without Defline**
```
-----------------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

**Good with Defline**
```
> foo bar
----------------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

**Good without Defline**
```
----------------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

**Bad on followup sequence**
```
> sequence 1
aaaaaaaaa
> sequence 2
-----------------aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
```

Resolves #200 